### PR TITLE
feat: add runtime module

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ return compiled({name: "world"});
 // File: helpers.js
 
 // Get Handlebars instance
-var Handlebars = require('handlebars-template-loader').Handlebars;
+var Handlebars = require('handlebars-template-loader/runtime');
 
 Handlebars.registerHelper('list', function(items, options) {
   var out = "<ul>";

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var Handlebars = require('handlebars');
-var HbsRuntime = require('handlebars/runtime');
+var HbsRuntime = require('./runtime');
 var loaderUtils = require('loader-utils');
 var path = require('path');
 

--- a/runtime/index.js
+++ b/runtime/index.js
@@ -1,0 +1,1 @@
+module.exports = require('handlebars/runtime');


### PR DESCRIPTION
Add runtime module to be able to only require Handlebars' runtime even when adding helpers/partials.
