### PR TITLE
This module doesnt work on Windows ("\" character)

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = function(content) {
     // Resolve attributes
     source = attributesContext.resolveAttributes(source);
 
-    callback(null, 'var Handlebars = require(\'' + require.resolve('handlebars/runtime') + '\');\n' +
+    callback(null, 'var Handlebars = require(\'' + require.resolve('handlebars/runtime').replace(/\\/g, '/') + '\');\n' +
         'module.exports = (Handlebars[\'default\'] || Handlebars).template(' + source + ');');
 };
 


### PR DESCRIPTION
Paths in windows are resolved with the "\" character between directories, so because you are evaluating raw output from the `resolve` function this means it gets interpreted as an escape character. The simplest solution is to replace "\" with "/" because windows allows both as directory separators.
